### PR TITLE
Prevent telemetry crash from leaking exception

### DIFF
--- a/src/mod/main.rb
+++ b/src/mod/main.rb
@@ -49,24 +49,24 @@ else
     begin
       # TODO: pass args, e.g context, location, etc...
       injected, err = injector.call
-
-      if err
-        telemetry.emit([
-          { :name => 'library_entrypoint.error', :tags => ["reason:#{err}"] },
-        ], { :result => report.errored(err) })
-      else
-        log.info { 'inject:complete' }
-
-        telemetry.emit([
-          { :name => 'library_entrypoint.complete' },
-        ], { :result => report.completed(injected) })
-      end
     rescue StandardError => e
       log.info { 'inject:error' }
 
       telemetry.emit([
         { :name => 'library_entrypoint.error', :tags => ["reason:exc.fatal"] },
       ], { :result => report.raised(e) })
+    end
+
+    if err
+      telemetry.emit([
+        { :name => 'library_entrypoint.error', :tags => ["reason:#{err}"] },
+      ], { :result => report.errored(err) })
+    else
+      log.info { 'inject:complete' }
+
+      telemetry.emit([
+        { :name => 'library_entrypoint.complete' },
+      ], { :result => report.completed(injected) })
     end
   end
 end

--- a/src/mod/telemetry.rb
+++ b/src/mod/telemetry.rb
@@ -32,30 +32,34 @@ class << self
   private :payload
 
   def emit(*args)
-    opts = args.last.is_a?(Hash) ? args.pop : {}
-    points = args.shift
+    begin
+      opts = args.last.is_a?(Hash) ? args.pop : {}
+      points = args.shift
 
-    LOG.info { "telemetry:emit points:#{points.inspect}" }
+      LOG.info { "telemetry:emit points:#{points.inspect}" }
 
-    pid = opts[:pid] || PROCESS.pid # TODO: emit from isolate
-    version = opts[:version] || package_version
-    result = opts[:result]
+      pid = opts[:pid] || PROCESS.pid # TODO: emit from isolate
+      version = opts[:version] || package_version
+      result = opts[:result]
 
-    forwarder = ENV['DD_TELEMETRY_FORWARDER_PATH']
+      forwarder = ENV['DD_TELEMETRY_FORWARDER_PATH']
 
-    return unless forwarder && !forwarder.empty?
+      return unless forwarder && !forwarder.empty?
 
-    rd, wr = IO.pipe
+      rd, wr = IO.pipe
 
-    pid = PROCESS.spawn(forwarder, 'library_entrypoint', { :in => rd, [:out, :err] => '/dev/null' })
+      pid = PROCESS.spawn(forwarder, 'library_entrypoint', { :in => rd, [:out, :err] => '/dev/null' })
 
-    wr.write(payload(pid, version, result, points))
-    wr.flush
-    wr.close
+      wr.write(payload(pid, version, result, points))
+      wr.flush
+      wr.close
 
-    cpid, status = Process.waitpid2(pid)
+      cpid, status = Process.waitpid2(pid)
 
-    LOG.info { "telemetry:forwarder cpid:#{cpid} status:#{status}" }
+      LOG.info { "telemetry:forwarder cpid:#{cpid} status:#{status}" }
+    rescue StandardError => exc
+      LOG.info { "telemetry:error exc:#{exc}" }
+    end
   end
 
   # TODO: extract to a package module


### PR DESCRIPTION
### Why?
<!-- What inspired you to submit this pull request? -->

- If an exception happens after telemetry has been sent but before returning from `main`'s `begin`..`end` block, two telemetry events may be emitted, which contradicts the "one start" => "one conclusion" design.
- `context.status` could raise exceptions in some situations
- `guard.call` may raise an exception but that's very unlikely

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- [X] tighten exception catching around injection in `main`
- [X] prevent telemetry from bubbling an exception up (we can't do anything in this case anyway)

### How to test the change?
<!-- Describe here how the change can be validated. -->
CI

### Additional Notes:
<!-- Anything else we should know when reviewing? -->
