### PR TITLE
Pin Docker version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Set up Docker with containerd
         uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
         with:
+          version: v28.5.1
           daemon-config: |
             {
               "features": {


### PR DESCRIPTION
### Why?
<!-- What inspired you to submit this pull request? -->

```
Run docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19
  with:
    daemon-config: {
    "features": {
      "containerd-snapshotter": true
    }
  }
  
    version: latest
    set-host: false
    rootless: false
Download docker
  Downloading Docker latest from stable at download.docker.com
  Downloading https://download.docker.com/linux/static/stable/aarch64/docker-docker-v29.0.2.tgz
Error: Unexpected HTTP response: 404
```

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin docker so that it doesn't change under our feet.

### How to test the change?
<!-- Describe here how the change can be validated. -->

- CI should run properly
- Docker URL should not have `docker-` twice

### Additional Notes:
<!-- Anything else we should know when reviewing? -->
