### PR TITLE
Address platform mismatch in remote resolution mode

### DIFF
--- a/src/mod/context.rb
+++ b/src/mod/context.rb
@@ -86,7 +86,7 @@ class << self
         :ruby => {
           :package => package,
           :force => Hash[ENV['DD_INTERNAL_RUBY_INJECTOR_FORCE'].tap { |s| break(s && s.split(',').map(&:strip) || []) }.map { |k| [k, true] }],
-          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'remote' ? :remote : :local,
+          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local' ? :local : :remote,
         },
       },
       :ruby => {

--- a/src/mod/context.rb
+++ b/src/mod/context.rb
@@ -86,7 +86,7 @@ class << self
         :ruby => {
           :package => package,
           :force => Hash[ENV['DD_INTERNAL_RUBY_INJECTOR_FORCE'].tap { |s| break(s && s.split(',').map(&:strip) || []) }.map { |k| [k, true] }],
-          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local' ? :local : :remote,
+          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'remote' ? :remote : :local,
         },
       },
       :ruby => {

--- a/src/mod/context.rb
+++ b/src/mod/context.rb
@@ -85,7 +85,8 @@ class << self
         :preload => {},
         :ruby => {
           :package => package,
-          :force => Hash[ENV['DD_INTERNAL_RUBY_INJECTOR_FORCE'].tap { |s| break(s && s.split(',').map(&:strip) || []) }.map { |k| [k, true] }]
+          :force => Hash[ENV['DD_INTERNAL_RUBY_INJECTOR_FORCE'].tap { |s| break(s && s.split(',').map(&:strip) || []) }.map { |k| [k, true] }],
+          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local' ? :local : :remote,
         },
       },
       :ruby => {

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -82,7 +82,18 @@ module Patch
             @definition.send(:sources).local_only!
             @definition.resolve
           else
-            @definition.resolve_remotely!
+            if Gem::Requirement.new('< 2.4.4').satisfied_by? Gem::Version.new(Bundler::VERSION)
+              @definition.resolve_prefering_local!
+            elsif Gem::Requirement.new('< 2.5.11').satisfied_by? Gem::Version.new(Bundler::VERSION)
+              @definition.resolution_mode = { 'prefer-local' => true }
+              @definition.resolve_remotely!
+            elsif Gem::Requirement.new('< 2.6.4').satisfied_by? Gem::Version.new(Bundler::VERSION)
+              @definition.prefer_local!
+              @definition.resolve_remotely!
+            else
+              @definition.send(:sources).prefer_local!
+              @definition.resolve_remotely!
+            end
           end
         rescue StandardError => e
           raise ResolutionError.new("Failed to resolve injected gemfile", e)

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -78,7 +78,7 @@ module Patch
         # Aborts when gems are incompatible
         begin
           # TODO: resolve only locally once we're confident
-          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local'
+          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] != 'remote'
             # SourceList#local_only! appears to exist consistently so far
             # - https://github.com/ruby/rubygems/blob/v3.4.0/bundler/lib/bundler/source_list.rb#L143
             # - https://github.com/ruby/rubygems/blob/v4.0.4/bundler/lib/bundler/source_list.rb#L121

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -78,7 +78,7 @@ module Patch
         # Aborts when gems are incompatible
         begin
           # TODO: resolve only locally once we're confident
-          if  ENV['DD_INTERNAL_RUBY_INJECTOR_LOCAL_RESOLUTION'] == 'true'
+          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local'
             @definition.send(:sources).local_only!
             @definition.resolve
           else

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -78,7 +78,7 @@ module Patch
         # Aborts when gems are incompatible
         begin
           # TODO: resolve only locally once we're confident
-          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] != 'remote'
+          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local'
             # SourceList#local_only! appears to exist consistently so far
             # - https://github.com/ruby/rubygems/blob/v3.4.0/bundler/lib/bundler/source_list.rb#L143
             # - https://github.com/ruby/rubygems/blob/v4.0.4/bundler/lib/bundler/source_list.rb#L121

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -79,9 +79,28 @@ module Patch
         begin
           # TODO: resolve only locally once we're confident
           if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local'
+            # SourceList#local_only! appears to exist consistently so far
+            # - https://github.com/ruby/rubygems/blob/v3.4.0/bundler/lib/bundler/source_list.rb#L143
+            # - https://github.com/ruby/rubygems/blob/v4.0.4/bundler/lib/bundler/source_list.rb#L121
+            # Definition#sources went public on 3.5.23
+            # - https://github.com/ruby/rubygems/commit/0d1252078053879ebc8a69abc243397af46f218a
             @definition.send(:sources).local_only!
             @definition.resolve
           else
+            # Remote resolution with local preference saw many iterations:
+            # - SourceList#prefer_local! appeared on 2.6.4, ultimately replacing Definition#prefer_local!
+            #   https://github.com/ruby/rubygems/commit/209b93ad3679edb79585f831ac4b0046b045ce49
+            #   https://github.com/ruby/rubygems/commit/3df86cd9c640655ec6ec85c1a2280621b56e7b77
+            #   https://github.com/ruby/rubygems/commit/c034f30aa925748cda0967c13e31e25fa73bc5f1
+            # - Definition#prefer_local! appeared on 2.5.11, dropping Definition#resolution_mode=
+            #   https://github.com/ruby/rubygems/commit/639f0b72f40979b552b4bae44a122cfd176115aa
+            #   https://github.com/ruby/rubygems/commit/bed579a49a554b8b205d2b0b5b1e85d356636c2c
+            # - Definition#resolution_mode= appeared on 2.4.4, replacing Definition#resolve_prefering_local!
+            #   https://github.com/ruby/rubygems/commit/47136c6b97c3385a4aea12f0eb0af1ba864f1924
+            #   https://github.com/ruby/rubygems/commit/f8333a735d4c1226261db6d457261567f1021aaa
+            # - Definition#resolve_prefering_local! appeared on 2.3.20
+            #   https://github.com/ruby/rubygems/commit/f0d6d4c57e68b8d6db8c6b979db2866d419c59bd
+            #   https://github.com/ruby/rubygems/commit/9bc5ebeb95204ecfb73e0f5a6181e37742563a4a
             if Gem::Requirement.new('< 2.4.4').satisfied_by? Gem::Version.new(Bundler::VERSION)
               @definition.resolve_prefering_local!
             elsif Gem::Requirement.new('< 2.5.11').satisfied_by? Gem::Version.new(Bundler::VERSION)
@@ -108,6 +127,9 @@ module Patch
 
         # Dump dependency resolution as a lockfile on disk
         begin
+          # Definition#lock changed signature on 2.5.6
+          # - https://github.com/ruby/rubygems/commit/2e282343a88db4373bbecead5ece293b5802526c
+          # - https://github.com/ruby/rubygems/commit/7f801a3ff424ac6ac91f68ad988df5b78cebf99b
           if Gem::Requirement.new('< 2.5.6').satisfied_by? Gem::Version.new(Bundler::VERSION)
             @definition.lock(lockfile_path)
           else

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -1050,7 +1050,7 @@ def main(argv)
           env['DD_INTERNAL_RUBY_INJECTOR_BASEPATH'] = "#{INJECTION_DIR}/test/packages/#{group[:injector] || 'datadog'}"
 
           # HACK: test with local resolution
-          env['DD_INTERNAL_RUBY_INJECTOR_LOCAL_RESOLUTION'] = 'true' unless group[:resolve] == :remote
+          env['DD_INTERNAL_RUBY_INJECTOR_LOCAL_RESOLUTION'] = 'true' if group[:resolve] == :local
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -1055,7 +1055,7 @@ def main(argv)
           env['DD_INTERNAL_RUBY_INJECTOR_BASEPATH'] = "#{INJECTION_DIR}/test/packages/#{group[:injector] || 'datadog'}"
 
           # HACK: test with local resolution
-          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'local' if group[:resolution] == :local
+          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'remote' if group[:resolution] == :remote
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -328,6 +328,9 @@ SUITE = [
         'reported result type should be success',
       ],
     },
+
+    [{ resolution: :remote }, { resolution: :local }] => [
+
     { fixture: 'frozen', inject: true, injector: 'datadog', packaged: true } => {
       [
         { engine: 'ruby', version: '2.6' },
@@ -547,6 +550,8 @@ SUITE = [
         ]
       }
     }
+
+    ]
   ]
 ]
 
@@ -1050,7 +1055,7 @@ def main(argv)
           env['DD_INTERNAL_RUBY_INJECTOR_BASEPATH'] = "#{INJECTION_DIR}/test/packages/#{group[:injector] || 'datadog'}"
 
           # HACK: test with local resolution
-          env['DD_INTERNAL_RUBY_INJECTOR_LOCAL_RESOLUTION'] = 'true' if group[:resolve] == :local
+          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'local' if group[:resolution] == :local
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -1055,7 +1055,7 @@ def main(argv)
           env['DD_INTERNAL_RUBY_INJECTOR_BASEPATH'] = "#{INJECTION_DIR}/test/packages/#{group[:injector] || 'datadog'}"
 
           # HACK: test with local resolution
-          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'remote' if group[:resolution] == :remote
+          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'local' if group[:resolution] == :local
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -802,7 +802,7 @@ def resolve_arch(runtime_arches)
   arches_for_platform.find { |arch| runtime_arches.include?(arch) }
 end
 
-def run(*args, engine: nil, version: nil, arch: nil, title: nil)
+def run(*args, engine: nil, version: nil, arch: nil, title: nil, network: true)
   env = args.first.is_a?(Hash) ? args.shift : {}
 
   runtime = RUNTIMES[engine][version] if engine && version
@@ -827,6 +827,10 @@ def run(*args, engine: nil, version: nil, arch: nil, title: nil)
     cmd += %W[
       --interactive --tty
     ] if $stdout.isatty
+
+    cmd += %W[
+      --network none
+    ] unless network
 
     cmd += %W[
       --volume #{INJECTION_DIR}:#{INJECTION_DIR}:rw
@@ -1059,13 +1063,17 @@ def main(argv)
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 
+          network = group[:resolution] != :local
+
           pid, status = if lock
                           run env, *%W[ bundle exec ruby stub.rb ],
                               engine: group[:engine], version: group[:version],
+                              network: network,
                               title: 'run fixture stub'
                         else
                           run env, *%W[ ruby stub.rb ],
                               engine: group[:engine], version: group[:version],
+                              network: network,
                               title: 'run fixture stub'
                         end
 

--- a/test/packages/datadog/ruby/2.6.0/Gemfile
+++ b/test/packages/datadog/ruby/2.6.0/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true
 
 # Ruby 2.6 decided to activate the default gem via `Kernel.gem` which makes it
 # subject to isolation, hence breaking under vendored mode.

--- a/test/packages/datadog/ruby/2.7.0/Gemfile
+++ b/test/packages/datadog/ruby/2.7.0/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/3.0.0/Gemfile
+++ b/test/packages/datadog/ruby/3.0.0/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/3.1.0/Gemfile
+++ b/test/packages/datadog/ruby/3.1.0/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/3.2.0/Gemfile
+++ b/test/packages/datadog/ruby/3.2.0/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/3.3.0/Gemfile
+++ b/test/packages/datadog/ruby/3.3.0/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/3.4.0/Gemfile
+++ b/test/packages/datadog/ruby/3.4.0/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/3.5.0+0/Gemfile
+++ b/test/packages/datadog/ruby/3.5.0+0/Gemfile
@@ -4,4 +4,4 @@ gem 'datadog'
 gem 'libddwaf', force_ruby_platform: true
 gem 'libdatadog', force_ruby_platform: true
 gem 'logger'
-gem 'ffi', '1.16.3'
+gem 'ffi', '1.16.3', force_ruby_platform: true


### PR DESCRIPTION
### Why?
<!-- What inspired you to submit this pull request? -->

With remote resolution mode being the default, failures happened in testing when integrating into `dd-trace-rb`:

- [Vaccine](https://github.com/DataDog/dd-trace-rb/pull/5238#issuecomment-3756653687)

  ```
  /root/.rbenv/versions/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/definition.rb:540:in `materialize': Could not find libdatadog-25.0.0.1.0-x86_64-linux, libddwaf-1.30.0.0.0-x86_64-linux in locally installed gems (Bundler::GemNotFound)
  ```

- [System Tests](https://github.com/DataDog/dd-trace-rb/pull/5238#issuecomment-3756671649)

  ```
  /root/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.4.22/lib/bundler/definition.rb:540:in 'Bundler::Definition#materialize': Could not find libdatadog-25.0.0.1.0-aarch64-linux, libddwaf-1.30.0.0.0-aarch64-linux in locally installed gems (Bundler::GemNotFound)
  ```

These were fixed by reverting the part that packaged gems using the `ruby` platform.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- [x] Investigate platform mismatch happening.
- [x] Perform remote resolution _with a local preference_.

### How to test the change?
<!-- Describe here how the change can be validated. -->

CI

### Additional Notes:
<!-- Anything else we should know when reviewing? -->

This appears to affect only `rubygems` < 3.7 / `bundler` < 2.7