### PR TITLE
Support vendored mode

### DIFF
--- a/src/mod/bundler.rb
+++ b/src/mod/bundler.rb
@@ -39,12 +39,14 @@ class << self
 
     mod = Module.new do
       def [](name)
-
-        if name == :deployment
-          return false
-        end
+        return false if name == :deployment
+        return nil if name == :path
 
         super
+      end
+
+      def path
+        ::Bundler::Settings::Path.new(nil, true)
       end
     end
 

--- a/src/mod/bundler.rb
+++ b/src/mod/bundler.rb
@@ -37,6 +37,38 @@ class << self
   def patch!
     require!
 
+    # Patch Bundler::Settings to neutralize deployment and vendored mode
+    # restrictions so that Bundler doesn't complain about gemfile/lockfile
+    # changes made by the injector or restrict gem activation.
+    #
+    # Two things need patching:
+    #
+    # 1. Settings#[] — intercepted for :deployment and :path.
+    #
+    #    :deployment (BOOL_KEYS) is returned as false so Bundler doesn't
+    #    enforce frozen gemfile/lockfile checks at runtime.
+    #
+    #    :path (STRING_KEYS) is returned as nil so any direct readers
+    #    (e.g. Bundler.settings[:path]) see no explicit path configured.
+    #    However, Settings#[] alone is NOT sufficient for :path because
+    #    Settings#path (the method) reads from config hashes directly via
+    #    value_for(), bypassing #[]. That's why we also need (2).
+    #
+    # 2. Settings#path (the method) — overridden to return Path.new(nil, true).
+    #
+    #    Bundler.bundle_path is derived from settings.path via
+    #    Bundler.configured_bundle_path. The original Settings#path iterates
+    #    over config levels (temporary, local, env, global) using value_for()
+    #    to find the "path" setting, and falls back to "vendor/bundle" when
+    #    deployment mode is on:
+    #
+    #    - https://github.com/ruby/rubygems/blob/v3.6.2/bundler/lib/bundler/settings.rb#L252-L265
+    #
+    #    By returning Path.new(nil, true) (no explicit_path, system_path=true),
+    #    Path#use_system_gems? returns true, and Path#base_path falls through
+    #    to Bundler.rubygems.gem_dir (i.e. Gem.dir), which is governed by
+    #    GEM_HOME/GEM_PATH that we've already set up in injector.rb to include
+    #    both the package gem home and the app's bundle path.
     mod = Module.new do
       def [](name)
         return false if name == :deployment

--- a/src/mod/guard.rb
+++ b/src/mod/guard.rb
@@ -53,10 +53,6 @@ class << self
       result << { :name => 'bundler.locked', :reason => 'bundler.unlocked' }
     end
 
-    if !status[:inject][:ruby][:force]['bundler.path'] && status[:bundler][:settings][:path]
-      result << { :name => 'bundler.path', :reason => 'bundler.vendored' }
-    end
-
     if !status[:inject][:ruby][:force]['bundler.platform.ruby'] && status[:bundler][:settings][:force_ruby_platform]
       result << { :name => 'bundler.platform.ruby', :reason => 'bundler.platform.forced' }
     end

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -246,19 +246,73 @@ class << self
 
     return [false, nil] unless gemfile
 
+    # Detect vendored or deployment mode.
+    #
+    # Vendored mode: BUNDLE_PATH is set (via env, .bundle/config, etc.),
+    # causing Bundler to install and load gems from that specific directory
+    # rather than the system gem path. This is the general case.
+    #
+    # Deployment mode: BUNDLE_DEPLOYMENT is set, which implies vendored mode
+    # (Bundler defaults BUNDLE_PATH to "vendor/bundle") and additionally
+    # freezes the Gemfile and lockfile.
+    #
+    # Vendored is checked last so it takes precedence: when both are set,
+    # the explicit BUNDLE_PATH matters more than the deployment default.
     mode = :deployment if context[:bundler][:deployment]
     mode = :vendored if context[:bundler][:settings][:path]
 
+    # In vendored or deployment mode, Bundler restricts gem loading to the
+    # bundle path. The injected gems live in the package gem home, not in
+    # the app's bundle path, so we must:
+    #
+    # 1. Set GEM_PATH to include both the package gem home (where injected
+    #    gems are installed) and the app's bundle path (where app gems are
+    #    installed), so RubyGems can find gems from both locations.
+    #
+    # 2. Set GEM_HOME to the app's bundle path so that any gem installation
+    #    goes to the expected location.
+    #
+    # 3. Patch Bundler settings (via BUNDLER.patch!) to neutralize the
+    #    deployment flag and the path setting, preventing Bundler from
+    #    complaining about gemfile/lockfile changes or restricting gem
+    #    activation to only the bundle path. See bundler.rb patch! for
+    #    details on what gets patched.
+    #
+    # 4. Persist the mode and paths in DD_INTERNAL_RUBY_INJECTOR_PATCH so
+    #    that child processes (e.g. via `bundle exec`) can re-apply the
+    #    patch. See main.rb's re-entry path.
     if mode == :deployment || mode == :vendored
       app_bundle_path = context[:bundler][:bundle_path]
 
       ENV['DD_INTERNAL_RUBY_INJECTOR_PATCH'] = "mode=#{mode},path=#{package_gem_home}:#{app_bundle_path}"
+
+      # Reset RubyGems' in-memory path state so gems from both locations are
+      # discoverable in the current process. Gem.paths= calls clear_paths and
+      # builds a new PathSupport from ENV.to_hash merged with the given hash.
+      # PathSupport#split_gem_path splits GEM_PATH, appends GEM_HOME, and
+      # deduplicates. Note: Gem.paths= does NOT modify ENV — it only sets
+      # the in-memory @paths and updates Gem::Specification.dirs.
       Gem.paths = { 'GEM_PATH' => "#{package_gem_home}:#{app_bundle_path}" }
+
+      # Persist the fully resolved Gem.path to ENV for child processes.
+      # Gem.path may include additional entries beyond what we explicitly set
+      # (e.g. the current GEM_HOME appended by PathSupport), so we read it
+      # back rather than recomputing it.
       ENV['GEM_PATH'] = Gem.path.join(File::PATH_SEPARATOR)
+
+      # Set GEM_HOME in ENV for child processes. This does not reset @paths
+      # or Gem.dir in the current process, but child processes (and any
+      # future Gem.paths reset) will resolve GEM_HOME to the app's bundle
+      # path, where app gems are installed.
       ENV['GEM_HOME'] = app_bundle_path
 
       BUNDLER.patch!
     else
+      # Non-vendored mode: Bundler uses system gems (no BUNDLE_PATH set),
+      # so we only need to prepend the package gem home to the existing
+      # GEM_PATH. No GEM_HOME override is needed (system default is fine),
+      # and no Bundler settings patch is needed since there are no
+      # deployment/path restrictions to neutralize.
       Gem.paths = { 'GEM_PATH' => "#{package_gem_home}:#{ENV['GEM_PATH']}" }
       ENV['GEM_PATH'] = Gem.path.join(File::PATH_SEPARATOR)
     end

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -246,10 +246,13 @@ class << self
 
     return [false, nil] unless gemfile
 
-    if context[:bundler][:deployment]
+    mode = :deployment if context[:bundler][:deployment]
+    mode = :vendored if context[:bundler][:settings][:path]
+
+    if mode == :deployment || mode == :vendored
       app_bundle_path = context[:bundler][:bundle_path]
 
-      ENV['DD_INTERNAL_RUBY_INJECTOR_PATCH'] = "mode=deployment,path=#{package_gem_home}:#{app_bundle_path}"
+      ENV['DD_INTERNAL_RUBY_INJECTOR_PATCH'] = "mode=#{mode},path=#{package_gem_home}:#{app_bundle_path}"
       Gem.paths = { 'GEM_PATH' => "#{package_gem_home}:#{app_bundle_path}" }
       ENV['GEM_PATH'] = Gem.path.join(File::PATH_SEPARATOR)
       ENV['GEM_HOME'] = app_bundle_path

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -131,15 +131,17 @@ SUITE = [
         { engine: 'ruby', version: '3.2' },
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
-        { engine: 'ruby', version: '3.5' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
-        'injection should abort',
-        'abort reason should include bundler.vendored',
+        'injection should proceed',
+        'injection should succeed',
+        'telemetry should include complete',
+        'abort reason should be empty',
         'telemetry start should not include result report',
         'telemetry conclusion should include result report',
-        'reported result type should be abort',
+        'reported result type should be success',
       ],
     },
     [{ fixture: 'deployment' }, { fixture: 'hot', env: 'BUNDLE_DEPLOYMENT=true' }] => {
@@ -245,15 +247,17 @@ SUITE = [
         { engine: 'ruby', version: '3.2' },
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
-        { engine: 'ruby', version: '3.5' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
-        'injection should abort',
-        'abort reason should include bundler.vendored',
+        'injection should proceed',
+        'injection should succeed',
+        'telemetry should include complete',
+        'abort reason should be empty',
         'telemetry start should not include result report',
         'telemetry conclusion should include result report',
-        'reported result type should be abort',
+        'reported result type should be success',
       ],
     },
     { fixture: 'hot' } => {
@@ -329,7 +333,7 @@ SUITE = [
       ],
     },
 
-    [{ resolution: :remote }, { resolution: :local }] => [
+    [{ resolution: :local }] => [
 
     { fixture: 'frozen', inject: true, injector: 'datadog', packaged: true } => {
       [
@@ -415,19 +419,20 @@ SUITE = [
         { engine: 'ruby', version: '3.2' },
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
       ] => [
         'telemetry should include metadata.tracer_version',
-        'telemetry should include start',
-        'injection should abort',
+        'telemetry should include complete',
         'app gemfile should not include datadog',
         'app lockfile should not include datadog',
-      # TODO: disabled due to race condition on naive deletion
-      # 'new gemfile should not exist',
-      # 'new lockfile should not exist',
-        'abort reason should include bundler.vendored',
+        'new gemfile should exist',
+        'new lockfile should exist',
+        'new gemfile should include datadog',
+        'new lockfile should include datadog',
+        'gem datadog should have require option',
         'telemetry start should not include result report',
         'telemetry conclusion should include result report',
-        'reported result type should be abort',
+        'reported result type should be success',
       ],
     },
     [{ fixture: 'vendored', env: 'BUNDLE_DEPLOYMENT=true', inject: true, injector: 'datadog', packaged: true }, { fixture: 'deployment', env: 'BUNDLE_PATH=/bundle', inject: true, injector: 'datadog', packaged: true }] => {
@@ -439,19 +444,20 @@ SUITE = [
         { engine: 'ruby', version: '3.2' },
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
       ] => [
         'telemetry should include metadata.tracer_version',
-        'telemetry should include start',
-        'injection should abort',
+        'telemetry should include complete',
         'app gemfile should not include datadog',
         'app lockfile should not include datadog',
-      # TODO: disabled due to race condition on naive deletion
-      # 'new gemfile should not exist',
-      # 'new lockfile should not exist',
-        'abort reason should include bundler.vendored',
+        'new gemfile should exist',
+        'new lockfile should exist',
+        'new gemfile should include datadog',
+        'new lockfile should include datadog',
+        'gem datadog should have require option',
         'telemetry start should not include result report',
         'telemetry conclusion should include result report',
-        'reported result type should be abort',
+        'reported result type should be success',
       ],
     },
     { fixture: 'deployment', inject: true, injector: 'datadog', packaged: true } => {


### PR DESCRIPTION
### Why?
<!-- What inspired you to submit this pull request? -->

- `BUNDLE_PATH` may be set
- ~Bundler 4 wants to default to vendored mode~ [actually delayed to Bundler 5](https://github.com/ruby/rubygems/commit/c314d7b25156657c47e7aace95772c2c56ea189e) but might be reverted at some point, plus it is possible to set "Bundler 5 mode".

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Patch path setting + apply same technique as for deployment mode, which implicitly sets vendored mode to an internal value.

The correct path value was already obtained from context, irrespective of mode.

### How to test the change?
<!-- Describe here how the change can be validated. -->

CI

### Additional Notes:
<!-- Anything else we should know when reviewing? -->

Might shove Bundler 4 support in, depending on testing.