### PR TITLE
Resolve locally by default

### DIFF
--- a/src/mod/context.rb
+++ b/src/mod/context.rb
@@ -86,7 +86,7 @@ class << self
         :ruby => {
           :package => package,
           :force => Hash[ENV['DD_INTERNAL_RUBY_INJECTOR_FORCE'].tap { |s| break(s && s.split(',').map(&:strip) || []) }.map { |k| [k, true] }],
-          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local' ? :local : :remote,
+          :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'remote' ? :remote : :local,
         },
       },
       :ruby => {

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -77,8 +77,9 @@ module Patch
         #
         # Aborts when gems are incompatible
         begin
-          # TODO: resolve only locally once we're confident
-          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'local'
+          # TODO: resolve only locally once we're confident (negative condition
+          # is a bit ugly but the whole condition is due to be removed)
+          if ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] != 'remote'
             # SourceList#local_only! appears to exist consistently so far
             # - https://github.com/ruby/rubygems/blob/v3.4.0/bundler/lib/bundler/source_list.rb#L143
             # - https://github.com/ruby/rubygems/blob/v4.0.4/bundler/lib/bundler/source_list.rb#L121

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -1058,12 +1058,12 @@ def main(argv)
           # HACK: default to 'datadog' package for stored metadata (version) to be picked up
           env['DD_INTERNAL_RUBY_INJECTOR_BASEPATH'] = "#{INJECTION_DIR}/test/packages/#{group[:injector] || 'datadog'}"
 
-          # HACK: test with local resolution
-          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'local' if group[:resolution] == :local
+          # test with local resolution by default
+          env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'remote' if group[:resolution] == :remote
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 
-          network = group[:resolution] != :local
+          network = group[:resolution] == :remote
 
           pid, status = if lock
                           run env, *%W[ bundle exec ruby stub.rb ],


### PR DESCRIPTION
### Why?
<!-- What inspired you to submit this pull request? -->

- Remote resolution has yet another case of oddball failure (preference of `libddwaf-1.30.0.0.0-aarch64-linux` over `ruby` platform `libddwaf-1.30.0.0.0`, which somehow didn't happen before)
- Local resolution appears to perform adequately

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Resolve locally by default
- Keep remote resolution as feature flagged emergency fallback

### How to test the change?
<!-- Describe here how the change can be validated. -->

CI

### Additional Notes:
<!-- Anything else we should know when reviewing? -->

Hopefully we're done with those resolution issues