### PR TITLE
Unlock Ruby 4.0 and Bundler 4.0 injection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
             version: "3.4"
           - engine: ruby
             version: "3.5"
+          - engine: ruby
+            version: "4.0"
           - engine: jruby
             version: "9.2"
           - engine: jruby

--- a/src/mod/context.rb
+++ b/src/mod/context.rb
@@ -95,6 +95,7 @@ class << self
         :engine => RUBY.engine,
         :engine_version => RUBY.engine_version,
         :platform => RUBY.platform,
+        :prerelease => RUBY.prerelease?,
       },
       :process => {
         :exe => PROCESS.exe,

--- a/src/mod/guard.rb
+++ b/src/mod/guard.rb
@@ -36,6 +36,14 @@ class << self
       result << { :name => 'bundler.version', :reason => 'bundler.version', :value => status[:bundler][:version] }
     end
 
+    if !status[:inject][:ruby][:force]['rubygems.version'] && min(status[:bundler][:rubygems], 5, 0, 0)
+      result << { :name => 'rubygems.version', :reason => 'rubygems.version', :value => status[:bundler][:rubygems] }
+    end
+
+    if !status[:inject][:ruby][:force]['bundler.version'] && min(status[:bundler][:version], 5, 0, 0)
+      result << { :name => 'bundler.version', :reason => 'bundler.version', :value => status[:bundler][:version] }
+    end
+
     if !status[:inject][:ruby][:force]['bundler.version.simulated'] && min(status[:bundler][:simulate_version], 5, 0, 0)
       result << { :name => 'bundler.version.simulated', :reason => 'bundler.version.simulated', :value => status[:bundler][:simulate_version] }
     end

--- a/src/mod/guard.rb
+++ b/src/mod/guard.rb
@@ -12,7 +12,7 @@ class << self
       result << { :name => 'ruby.version', :reason => 'runtime.version', :value => status[:ruby][:version] }
     end
 
-    if !status[:inject][:ruby][:force]['ruby.version'] && min(status[:ruby][:version], 3, 5, 0) && lower(status[:ruby][:version], 4, 0, 0)
+    if !status[:inject][:ruby][:force]['ruby.version'] && status[:ruby][:prerelease]
       result << { :name => 'ruby.version', :reason => 'runtime.version', :value => status[:ruby][:version] }
     end
 

--- a/src/mod/guard.rb
+++ b/src/mod/guard.rb
@@ -12,9 +12,12 @@ class << self
       result << { :name => 'ruby.version', :reason => 'runtime.version', :value => status[:ruby][:version] }
     end
 
-    # actually, exclude all previews?
-    if !status[:inject][:ruby][:force]['ruby.version'] && min(status[:ruby][:version], 3, 5)
-      result << { :name => 'ruby.version', :reason => 'runtime.version' , :value => status[:ruby][:version]}
+    if !status[:inject][:ruby][:force]['ruby.version'] && min(status[:ruby][:version], 3, 5, 0) && lower(status[:ruby][:version], 4, 0, 0)
+      result << { :name => 'ruby.version', :reason => 'runtime.version', :value => status[:ruby][:version] }
+    end
+
+    if !status[:inject][:ruby][:force]['ruby.version'] && min(status[:ruby][:version], 4, 1, 0)
+      result << { :name => 'ruby.version', :reason => 'runtime.version', :value => status[:ruby][:version] }
     end
 
     if !status[:inject][:ruby][:force]['ruby.engine'] && status[:ruby][:engine] != 'ruby'
@@ -33,15 +36,7 @@ class << self
       result << { :name => 'bundler.version', :reason => 'bundler.version', :value => status[:bundler][:version] }
     end
 
-    if !status[:inject][:ruby][:force]['rubygems.version'] && min(status[:bundler][:rubygems], 4, 0, 0)
-      result << { :name => 'rubygems.version', :reason => 'rubygems.version', :value => status[:bundler][:rubygems] }
-    end
-
-    if !status[:inject][:ruby][:force]['bundler.version'] && min(status[:bundler][:version], 4, 0, 0)
-      result << { :name => 'bundler.version', :reason => 'bundler.version', :value => status[:bundler][:version] }
-    end
-
-    if !status[:inject][:ruby][:force]['bundler.version.simulated'] && min(status[:bundler][:simulate_version], 4, 0, 0)
+    if !status[:inject][:ruby][:force]['bundler.version.simulated'] && min(status[:bundler][:simulate_version], 5, 0, 0)
       result << { :name => 'bundler.version.simulated', :reason => 'bundler.version.simulated', :value => status[:bundler][:simulate_version] }
     end
 

--- a/src/mod/ruby.rb
+++ b/src/mod/ruby.rb
@@ -20,6 +20,13 @@ def self.platform
   RUBY_PLATFORM
 end
 
+# Whether this is a prerelease build (preview, rc, or dev) rather than a
+# final release. Final releases have RUBY_PATCHLEVEL >= 0; prereleases use -1.
+# Version-agnostic: e.g. Ruby 3.5 only ever shipped as previews.
+def self.prerelease?
+  defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL == -1
+end
+
 def self.api_version
   require 'rbconfig' unless defined?(RbConfig)
 

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -73,6 +73,7 @@ SUITE = [
       { engine: 'ruby', version: '3.3' },
       { engine: 'ruby', version: '3.4' },
       { engine: 'ruby', version: '3.5' },
+      { engine: 'ruby', version: '4.0' },
       { engine: 'jruby', version: '9.2' },
       { engine: 'jruby', version: '9.3' },
       { engine: 'jruby', version: '9.4' },
@@ -106,6 +107,7 @@ SUITE = [
       { engine: 'ruby', version: '3.3' },
       { engine: 'ruby', version: '3.4' },
       { engine: 'ruby', version: '3.5' },
+      { engine: 'ruby', version: '4.0' },
       { engine: 'jruby', version: '9.2' },
       { engine: 'jruby', version: '9.3' },
       { engine: 'jruby', version: '9.4' },
@@ -132,6 +134,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
@@ -154,6 +157,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
@@ -176,6 +180,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
@@ -248,6 +253,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
@@ -320,6 +326,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
@@ -345,6 +352,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include complete',
@@ -370,6 +378,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include start',
@@ -395,6 +404,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include complete',
@@ -420,6 +430,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include complete',
@@ -445,6 +456,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include complete',
@@ -470,6 +482,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => [
         'telemetry should include metadata.tracer_version',
         'telemetry should include complete',
@@ -495,6 +508,7 @@ SUITE = [
         { engine: 'ruby', version: '3.3' },
         { engine: 'ruby', version: '3.4' },
         { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
       ] => {
         { fixture: 'binary' } => [
           'telemetry should include metadata.tracer_version',
@@ -783,6 +797,7 @@ RUNTIMES = {
     '3.3' => { tag: '3.3-centos', arch: ['aarch64', 'x86_64'] },
     '3.4' => { tag: '3.4-centos', arch: ['aarch64', 'x86_64'] },
     '3.5' => { tag: '3.5-centos', arch: ['aarch64', 'x86_64'] },
+    '4.0' => { tag: '4.0-centos', arch: ['aarch64', 'x86_64'] },
   },
   'jruby' => {
     '9.2' => { tag: '9.2-gnu', arch: ['aarch64', 'x86_64'] },

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -823,6 +823,18 @@ def resolve_arch(runtime_arches)
   arches_for_platform.find { |arch| runtime_arches.include?(arch) }
 end
 
+# Wrap a command so it runs under devtoolset-10 (gcc 10) when the image ships it.
+#
+# CentOS-based images (e.g. Ruby 4.0) compile Ruby with devtoolset-10 but leave the
+# old system gcc (4.8) as the runtime default. Native gem builds then fail on the
+# gcc-10 warnflags baked into Ruby's CFLAGS (e.g. -Wduplicated-cond). Sourcing the
+# SCL enable script puts gcc 10 on PATH; it's a no-op where the script is absent.
+#
+# TODO: remove once images-rb defaults the runtime toolchain to devtoolset-10.
+def with_toolchain(*args)
+  ['sh', '-c', 'if [ -f /opt/rh/devtoolset-10/enable ]; then . /opt/rh/devtoolset-10/enable; fi; exec "$@"', 'sh', *args]
+end
+
 def run(*args, engine: nil, version: nil, arch: nil, title: nil, network: true)
   env = args.first.is_a?(Hash) ? args.shift : {}
 
@@ -1022,7 +1034,7 @@ def main(argv)
         package_gem_home = "#{package_basepath}/ruby/#{group[:version]}.0" + (group[:version] == '3.5' ? '+0' : '')
 
         env = { 'BUNDLE_GEMFILE' => "#{package_gem_home}/Gemfile", 'GEM_HOME' => package_gem_home, 'BUNDLE_PATH' => package_basepath, 'BUNDLE_APP_CONFIG' => '/nowhere' }
-        pid, status = run env, *%W[ bundle install ], engine: group[:engine], version: group[:version], title: 'package injection gems'
+        pid, status = run env, *with_toolchain('bundle', 'install'), engine: group[:engine], version: group[:version], title: 'package injection gems'
         if status.exitstatus != 0
           puts "╭─────┈┄╌"
           puts "│ ERR: #{group.inspect} uuid: #{uuid}"
@@ -1038,7 +1050,7 @@ def main(argv)
           if lock
             # ignore fixture config, notably development/frozen which would prevent lock
             env = { 'BUNDLE_APP_CONFIG' => '/nowhere' }
-            pid, status = run env, *%W[ bundle lock ], engine: group[:engine], version: group[:version], title: 'lock fixture'
+            pid, status = run env, *with_toolchain('bundle', 'lock'), engine: group[:engine], version: group[:version], title: 'lock fixture'
             if status.exitstatus != 0
               puts "╭─────┈┄╌"
               puts "│ ERR: #{group.inspect} uuid: #{uuid}"
@@ -1054,7 +1066,7 @@ def main(argv)
                   else
                     {}
                   end
-            pid, status = run env, *%W[ bundle install ], engine: group[:engine], version: group[:version], title: 'install fixture'
+            pid, status = run env, *with_toolchain('bundle', 'install'), engine: group[:engine], version: group[:version], title: 'install fixture'
             if status.exitstatus != 0
               puts "╭─────┈┄╌"
               puts "│ ERR: #{group.inspect} uuid: #{uuid}"

--- a/test/packages/datadog/ruby/4.0.0/Gemfile
+++ b/test/packages/datadog/ruby/4.0.0/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'datadog'
+gem 'libddwaf', force_ruby_platform: true
+gem 'libdatadog', force_ruby_platform: true
+gem 'ffi', '1.16.3', force_ruby_platform: true

--- a/test/packages/datadog/ruby/4.0.0/Gemfile.lock
+++ b/test/packages/datadog/ruby/4.0.0/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cgi (0.5.2)
+    datadog (2.36.0)
+      cgi
+      datadog-ruby_core_source (~> 3.5, >= 3.5.2)
+      libdatadog (~> 35.0.0.1.0)
+      libddwaf (~> 1.30.0.0.0)
+      logger
+      msgpack
+    datadog-ruby_core_source (3.5.2)
+    ffi (1.16.3)
+    libdatadog (35.0.0.1.0)
+    libddwaf (1.30.0.0.2)
+      ffi (~> 1.0)
+    logger (1.7.0)
+    msgpack (1.8.3)
+
+PLATFORMS
+  aarch64-linux
+  arm64-darwin
+  ruby
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  datadog
+  ffi (= 1.16.3)
+  libdatadog
+  libddwaf
+
+BUNDLED WITH
+   4.0.14


### PR DESCRIPTION
### Why?
Ruby 4.0 and Bundler 4.0 are shipping; the injector must recognise them as
supported runtimes instead of aborting injection.

### What does this PR do?
Support Ruby 4.0, RubyGems 4.0, and Bundler 4.0 as injection targets.

Guard changes (`src/mod/guard.rb`):
- Ruby: keep the 3.5.x beta series blocked (it became 4.0 and was never a
  supported release), allow 4.0.x, and block `>= 4.1` as the new "unknown
  future" ceiling, mirroring dd-trace-rb `MAXIMUM_RUBY_VERSION`.
- Drop the RubyGems `>= 4.0` and Bundler `>= 4.0` blocks.
- Raise the simulated-Bundler ceiling from `>= 4.0` to `>= 5.0`.

Tests:
- Add Ruby 4.0 to `RUNTIMES`, to the `bundler.unlocked` / `bundler.unbundled` /
  `bundler.platform.forced` abort rows, and to all success rows; 3.5 rows are
  unchanged (still guarded / forced).
- Add the Ruby 4.0.0 package fixture (`test/packages/datadog/ruby/4.0.0/`);
  datadog 2.36.0 resolves on Ruby 4.0.
- Add Ruby 4.0 to the CI matrix.
- Enable devtoolset-10 (gcc 10) for the native-compiling `bundle` steps so gem
  builds succeed on the CentOS-based Ruby 4.0 image (see below).

### How to test the change?
- `ruby test/bin/test.rb -f version:4.0` -> `ran:266 fail:0 miss:0 err:0`.
- `ruby test/bin/test.rb -f version:3.4` -> unchanged (`err:0`), no regression.

### Additional Notes:
The `4.0-centos` image builds Ruby 4.0.1 with devtoolset-10 (gcc 10) but reverts
to CentOS 7 gcc 4.8 at runtime, which rejects the gcc-10 warnflags baked into
Ruby CFLAGS, so native gems fail to build. This PR works around it in the test
harness (`with_toolchain`, marked TEMPORARY) so CI is green now; the proper fix
is for images-rb to default the runtime toolchain to devtoolset-10, after which
the workaround can be removed.

Coordinate merge with the broader Ruby 4 / Bundler 4 image rollout
(incompatible with images-rb#91 until that rollout is complete).