### PR TITLE
Add experimental direct injection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,18 @@ Set `DD_INTERNAL_RUBY_INJECTOR_DIRECT=true` to load the packaged Datadog gem
 without generating an injected Gemfile or lockfile and without patching Bundler.
 The injector activates the application bundle normally, reuses compatible gems
 already activated by the application, and adds missing dependencies directly
-from the injection package.
+from the application bundle or injection package. It uses a deterministic
+backtracking resolver across the application bundle and every dependency version
+installed in the injection package. It prefers the package lockfile's versions,
+then backtracks to packaged alternatives when needed, and validates Ruby,
+RubyGems, platform, and transitive dependency constraints before changing the
+process. Datadog SDK candidates remain limited to the package lockfile; an SDK
+already activated by the application is immutable like every other loaded gem.
 
 Direct loading fails before loading Datadog when an application gem conflicts
-with the packaged dependency graph. This mode is experimental and is intended
+with the packaged dependency graph, a required platform build is absent, or the
+package does not contain any satisfiable dependency set. Already activated gems
+cannot be replaced safely in-process. This mode is experimental and is intended
 for testing read-only filesystem support.
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ ruby your_application.rb
 bundle exec ruby your_application.rb
 ```
 
+### Experimental direct loading
+
+Set `DD_INTERNAL_RUBY_INJECTOR_DIRECT=true` to load the packaged Datadog gem
+without generating an injected Gemfile or lockfile and without patching Bundler.
+The injector activates the application bundle normally, reuses compatible gems
+already activated by the application, and adds missing dependencies directly
+from the injection package.
+
+Direct loading fails before loading Datadog when an application gem conflicts
+with the packaged dependency graph. This mode is experimental and is intended
+for testing read-only filesystem support.
+
 ## Project Structure
 
 - `/src`: Contains the main injector code

--- a/src/mod/context.rb
+++ b/src/mod/context.rb
@@ -86,6 +86,7 @@ class << self
         :ruby => {
           :package => package,
           :force => Hash[ENV['DD_INTERNAL_RUBY_INJECTOR_FORCE'].tap { |s| break(s && s.split(',').map(&:strip) || []) }.map { |k| [k, true] }],
+          :direct => ENV['DD_INTERNAL_RUBY_INJECTOR_DIRECT'] == 'true',
           :resolution => ENV['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] == 'remote' ? :remote : :local,
         },
       },

--- a/src/mod/direct.rb
+++ b/src/mod/direct.rb
@@ -1,6 +1,7 @@
 # ruby-version-min: 1.8.7
 
 BUNDLER = import 'bundler'
+RESOLVER = import 'resolver'
 
 class DirectError < StandardError
   attr_reader :cause
@@ -26,8 +27,8 @@ class << self
 
     setup_bundle
 
-    selected, packaged = resolve(package[:gem_home], package[:lockfile])
-    activate(selected, packaged)
+    selected = resolve(package[:gem_home], package[:lockfile])
+    activate(selected)
 
     true
   end
@@ -52,18 +53,16 @@ class << self
   def resolve(gem_home, lockfile)
     begin
       locked = Bundler::LockfileParser.new(Bundler.read_file(lockfile))
-      available = load_package_specs(gem_home, locked.specs)
-      selected = {}
-      packaged = {}
+      available = load_candidates(gem_home, locked.specs)
       datadog = locked.dependencies['datadog']
 
       unless datadog
         raise ResolutionError.new('The injection package does not declare a datadog dependency')
       end
 
-      resolve_dependency(datadog, 'injection package', available, selected, packaged)
-
-      [selected, packaged]
+      RESOLVER::Resolver.new(available, Gem.loaded_specs).resolve(datadog)
+    rescue RESOLVER::Conflict => e
+      raise ResolutionError.new(e.message, e)
     rescue DirectError
       raise
     rescue StandardError => e
@@ -71,80 +70,66 @@ class << self
     end
   end
 
-  def load_package_specs(gem_home, locked_specs)
-    locked = {}
-    locked_specs.each { |spec| locked[[spec.name, spec.version.to_s]] = true }
-
+  def load_candidates(gem_home, locked_specs)
     available = {}
-    pattern = File.join(gem_home, 'specifications', '*.gemspec')
 
-    Dir[pattern].sort.each do |path|
-      spec = Gem::Specification.load(path)
-      next unless spec
-      next unless locked[[spec.name, spec.version.to_s]]
+    Bundler.load.specs.each do |spec|
+      # Datadog comes from the selected injection package. An application copy
+      # that is already active is still treated as immutable by the resolver.
+      next if spec.name == 'datadog'
 
-      available[spec.name] ||= []
-      available[spec.name] << spec
+      add_candidate(available, spec, :application)
+    end
+
+    load_package_candidates(gem_home, locked_specs).each do |candidate|
+      add_candidate(available, candidate[:spec], candidate[:source])
     end
 
     available
   end
 
-  def resolve_dependency(dependency, parent, available, selected, packaged)
-    if (spec = selected[dependency.name])
-      validate_requirement(dependency, parent, spec)
-      return spec
+  def load_package_candidates(gem_home, locked_specs)
+    locked = {}
+    locked_specs.each { |spec| locked[[spec.name, spec.version.to_s]] = true }
+
+    candidates = []
+    pattern = File.join(gem_home, 'specifications', '*.gemspec')
+
+    Dir[pattern].sort.each do |path|
+      spec = Gem::Specification.load(path)
+      next unless spec
+
+      is_locked = locked[[spec.name, spec.version.to_s]]
+
+      # The requested Datadog version is canonical, but additional packaged
+      # dependency versions are valid alternatives for the local resolver.
+      next if spec.name == 'datadog' && !is_locked
+
+      candidates << { :spec => spec, :source => (is_locked ? :package_locked : :package) }
     end
 
-    if (spec = Gem.loaded_specs[dependency.name])
-      validate_requirement(dependency, parent, spec)
-      selected[dependency.name] = spec
-      return spec
-    end
-
-    candidates = available[dependency.name] || []
-    spec = candidates.find { |candidate| dependency.requirement.satisfied_by?(candidate.version) }
-
-    unless spec
-      raise ResolutionError.new("#{parent} requires #{dependency}, but the injection package does not provide it")
-    end
-
-    validate_runtime(spec)
-
-    selected[dependency.name] = spec
-    packaged[dependency.name] = spec
-
-    spec.runtime_dependencies.each do |child|
-      resolve_dependency(child, spec.full_name, available, selected, packaged)
-    end
-
-    spec
+    candidates
   end
 
-  def validate_requirement(dependency, parent, spec)
-    return if dependency.requirement.satisfied_by?(spec.version)
-
-    raise ResolutionError.new("#{parent} requires #{dependency}, but #{spec.full_name} is already selected")
-  end
-
-  def validate_runtime(spec)
-    unless spec.required_ruby_version.satisfied_by?(Gem.ruby_version)
-      raise ResolutionError.new("#{spec.full_name} does not support Ruby #{Gem.ruby_version}")
+  def add_candidate(available, spec, source)
+    available[spec.name] ||= []
+    duplicate = available[spec.name].any? do |candidate|
+      candidate[:spec].version == spec.version && candidate[:spec].platform == spec.platform
     end
-
-    return if spec.required_rubygems_version.satisfied_by?(Gem::Version.new(Gem::VERSION))
-
-    raise ResolutionError.new("#{spec.full_name} does not support RubyGems #{Gem::VERSION}")
+    available[spec.name] << { :spec => spec, :source => source } unless duplicate
   end
 
-  def activate(selected, packaged)
-    datadog = selected['datadog']
+  def activate(selected)
+    datadog = selected['datadog'] && selected['datadog'][:spec]
     raise ResolutionError.new('The injection package does not resolve a datadog gem') unless datadog
 
     added_paths = []
     previous_specs = {}
 
-    packaged.each_value do |spec|
+    selected.each_value do |candidate|
+      next if candidate[:source] == :loaded
+
+      spec = candidate[:spec]
       spec.full_require_paths.each do |path|
         next if $LOAD_PATH.include?(path)
 

--- a/src/mod/direct.rb
+++ b/src/mod/direct.rb
@@ -1,0 +1,185 @@
+# ruby-version-min: 1.8.7
+
+BUNDLER = import 'bundler'
+
+class DirectError < StandardError
+  attr_reader :cause
+
+  def initialize(message, cause = nil)
+    super(message)
+
+    @cause = cause
+  end
+end
+
+class SetupError < DirectError; end
+class ResolutionError < DirectError; end
+class LoadError < DirectError; end
+
+class << self
+  def call(context)
+    # Let `bundle exec` carry the injector into the application process instead
+    # of loading Datadog into the short-lived Bundler CLI process.
+    return false if bundler_cli?(context)
+
+    package = context[:inject][:ruby][:package]
+
+    setup_bundle
+
+    selected, packaged = resolve(package[:gem_home], package[:lockfile])
+    activate(selected, packaged)
+
+    true
+  end
+
+  private
+
+  def bundler_cli?(context)
+    name = context[:process][:name]
+    name && ['bundle', 'bundler'].include?(File.basename(name))
+  end
+
+  def setup_bundle
+    BUNDLER.send(:require!)
+
+    begin
+      require 'bundler/setup'
+    rescue StandardError => e
+      raise SetupError.new('Failed to activate the application bundle', e)
+    end
+  end
+
+  def resolve(gem_home, lockfile)
+    begin
+      locked = Bundler::LockfileParser.new(Bundler.read_file(lockfile))
+      available = load_package_specs(gem_home, locked.specs)
+      selected = {}
+      packaged = {}
+      datadog = locked.dependencies['datadog']
+
+      unless datadog
+        raise ResolutionError.new('The injection package does not declare a datadog dependency')
+      end
+
+      resolve_dependency(datadog, 'injection package', available, selected, packaged)
+
+      [selected, packaged]
+    rescue DirectError
+      raise
+    rescue StandardError => e
+      raise ResolutionError.new('Failed to resolve direct injection dependencies', e)
+    end
+  end
+
+  def load_package_specs(gem_home, locked_specs)
+    locked = {}
+    locked_specs.each { |spec| locked[[spec.name, spec.version.to_s]] = true }
+
+    available = {}
+    pattern = File.join(gem_home, 'specifications', '*.gemspec')
+
+    Dir[pattern].sort.each do |path|
+      spec = Gem::Specification.load(path)
+      next unless spec
+      next unless locked[[spec.name, spec.version.to_s]]
+
+      available[spec.name] ||= []
+      available[spec.name] << spec
+    end
+
+    available
+  end
+
+  def resolve_dependency(dependency, parent, available, selected, packaged)
+    if (spec = selected[dependency.name])
+      validate_requirement(dependency, parent, spec)
+      return spec
+    end
+
+    if (spec = Gem.loaded_specs[dependency.name])
+      validate_requirement(dependency, parent, spec)
+      selected[dependency.name] = spec
+      return spec
+    end
+
+    candidates = available[dependency.name] || []
+    spec = candidates.find { |candidate| dependency.requirement.satisfied_by?(candidate.version) }
+
+    unless spec
+      raise ResolutionError.new("#{parent} requires #{dependency}, but the injection package does not provide it")
+    end
+
+    validate_runtime(spec)
+
+    selected[dependency.name] = spec
+    packaged[dependency.name] = spec
+
+    spec.runtime_dependencies.each do |child|
+      resolve_dependency(child, spec.full_name, available, selected, packaged)
+    end
+
+    spec
+  end
+
+  def validate_requirement(dependency, parent, spec)
+    return if dependency.requirement.satisfied_by?(spec.version)
+
+    raise ResolutionError.new("#{parent} requires #{dependency}, but #{spec.full_name} is already selected")
+  end
+
+  def validate_runtime(spec)
+    unless spec.required_ruby_version.satisfied_by?(Gem.ruby_version)
+      raise ResolutionError.new("#{spec.full_name} does not support Ruby #{Gem.ruby_version}")
+    end
+
+    return if spec.required_rubygems_version.satisfied_by?(Gem::Version.new(Gem::VERSION))
+
+    raise ResolutionError.new("#{spec.full_name} does not support RubyGems #{Gem::VERSION}")
+  end
+
+  def activate(selected, packaged)
+    datadog = selected['datadog']
+    raise ResolutionError.new('The injection package does not resolve a datadog gem') unless datadog
+
+    added_paths = []
+    previous_specs = {}
+
+    packaged.each_value do |spec|
+      spec.full_require_paths.each do |path|
+        next if $LOAD_PATH.include?(path)
+
+        $LOAD_PATH << path
+        added_paths << path
+      end
+
+      previous_specs[spec.name] = Gem.loaded_specs[spec.name]
+      Gem.loaded_specs[spec.name] = spec
+    end
+
+    begin
+      require File.join(datadog.full_gem_path, 'lib', 'datadog', 'single_step_instrument')
+
+      unless defined?(::Datadog::SingleStepInstrument::LOADED)
+        raise LoadError.new('Datadog single-step instrumentation did not load')
+      end
+    rescue LoadError
+      rollback(added_paths, previous_specs)
+      raise
+    rescue ::LoadError, StandardError => e
+      rollback(added_paths, previous_specs)
+      raise LoadError.new('Failed to load Datadog directly', e)
+    end
+  end
+
+  def rollback(added_paths, previous_specs)
+    added_paths.each { |path| $LOAD_PATH.delete(path) }
+
+    previous_specs.each do |name, spec|
+      if spec
+        Gem.loaded_specs[name] = spec
+      else
+        Gem.loaded_specs.delete(name)
+      end
+    end
+  end
+end

--- a/src/mod/guard.rb
+++ b/src/mod/guard.rb
@@ -60,7 +60,7 @@ class << self
       result << { :name => 'bundler.platform.ruby', :reason => 'bundler.platform.forced' }
     end
 
-    if !status[:inject][:ruby][:force]['fs.writable'] && !status[:fs][:writable]
+    if !status[:inject][:ruby][:direct] && !status[:inject][:ruby][:force]['fs.writable'] && !status[:fs][:writable]
       result << { :name => 'fs.writable', :reason => 'fs.readonly' }
     end
 

--- a/src/mod/injector.rb
+++ b/src/mod/injector.rb
@@ -3,6 +3,7 @@
 LOG = import 'log'
 CONTEXT = import 'context'
 BUNDLER = import 'bundler'
+DIRECT = import 'direct'
 
 module Patch
   module Injector
@@ -177,6 +178,8 @@ class << self
   def call(context)
     LOG.info { "injector:call context:#{context}" }
 
+    return call_direct(context) if context[:inject][:ruby][:direct]
+
     # TODO: check if nested injection (maybe very early too)
     # TODO: check if injection already performed
 
@@ -321,6 +324,21 @@ class << self
     ENV['BUNDLE_GEMFILE'] = gemfile
 
     [true, nil]
+  end
+
+  def call_direct(context)
+    begin
+      [DIRECT.call(context), nil]
+    rescue DIRECT::SetupError => e
+      LOG.debug { "injector:error code:bundler.direct.setup msg:#{e.message.inspect} cause:#{e.cause.inspect}" }
+      [nil, 'bundler.direct.setup']
+    rescue DIRECT::ResolutionError => e
+      LOG.debug { "injector:error code:bundler.direct.resolve msg:#{e.message.inspect} cause:#{e.cause.inspect}" }
+      [nil, 'bundler.direct.resolve']
+    rescue DIRECT::LoadError => e
+      LOG.debug { "injector:error code:bundler.direct.load msg:#{e.message.inspect} cause:#{e.cause.inspect}" }
+      [nil, 'bundler.direct.load']
+    end
   end
 
   def options_for(name)

--- a/src/mod/report.rb
+++ b/src/mod/report.rb
@@ -20,6 +20,8 @@ class << self
 
     # error reasons
     when 'bundler.inject'                then 'incompatible_dependency'
+    when 'bundler.direct.resolve'        then 'incompatible_dependency'
+    when /^bundler\.direct\./            then 'internal_error'
 
     # fallback
     else                                      'unknown'
@@ -62,6 +64,12 @@ class << self
     # error reasons
     when 'bundler.inject'
       'A dependency was found to be incompatible'
+    when 'bundler.direct.resolve'
+      'The activated application bundle is incompatible with direct injection'
+    when 'bundler.direct.setup'
+      'The application bundle could not be activated for direct injection'
+    when 'bundler.direct.load'
+      'Datadog could not be loaded directly from the injection package'
 
     # fallback
     else

--- a/src/mod/resolver.rb
+++ b/src/mod/resolver.rb
@@ -1,0 +1,184 @@
+# ruby-version-min: 1.8.7
+
+class Conflict < StandardError; end
+
+class Resolver
+  def initialize(available, loaded_specs)
+    @available = available
+    @loaded_specs = loaded_specs
+    @failed = {}
+  end
+
+  def resolve(root)
+    requirements = {}
+    add_requirement(requirements, root, 'injection package')
+
+    selected, conflict = search({}, requirements)
+    raise Conflict, conflict unless selected
+
+    selected
+  end
+
+  private
+
+  def search(selected, requirements)
+    if (conflict = selected_conflict(selected, requirements))
+      return [nil, conflict]
+    end
+
+    unresolved = requirements.keys.reject { |name| selected.key?(name) }
+    return [selected, nil] if unresolved.empty?
+
+    state = state_key(selected, requirements)
+    return [nil, @failed[state]] if @failed.key?(state)
+
+    name = unresolved.sort_by { |candidate_name| [candidates_for(candidate_name, requirements).length, candidate_name] }.first
+    candidates, unavailable = candidates_for(name, requirements, true)
+
+    if candidates.empty?
+      conflict = unavailable_message(name, requirements[name], unavailable)
+      @failed[state] = conflict
+      return [nil, conflict]
+    end
+
+    conflicts = []
+
+    candidates.each do |candidate|
+      next_selected = selected.dup
+      next_selected[name] = candidate
+      next_requirements = duplicate_requirements(requirements)
+
+      candidate[:spec].runtime_dependencies.each do |dependency|
+        add_requirement(next_requirements, dependency, candidate[:spec].full_name)
+      end
+
+      solution, conflict = search(next_selected, next_requirements)
+      return [solution, nil] if solution
+
+      conflicts << "#{candidate[:spec].full_name}: #{conflict}"
+    end
+
+    conflict = "Unable to resolve #{requirements_text(name, requirements[name])}; tried #{conflicts.join('; ')}"
+    @failed[state] = conflict
+    [nil, conflict]
+  end
+
+  def selected_conflict(selected, requirements)
+    requirements.keys.sort.each do |name|
+      candidate = selected[name]
+      next unless candidate
+
+      unsatisfied = requirements[name].reject do |request|
+        request[:dependency].requirement.satisfied_by?(candidate[:spec].version)
+      end
+      next if unsatisfied.empty?
+
+      suffix = candidate[:source] == :loaded ? ' is already activated' : ' is selected'
+      return "#{requirements_text(name, unsatisfied)}, but #{candidate[:spec].full_name}#{suffix}"
+    end
+
+    nil
+  end
+
+  def candidates_for(name, requirements, include_unavailable = false)
+    requests = requirements[name]
+    loaded = @loaded_specs[name]
+    pool = loaded ? [{ :spec => loaded, :source => :loaded }] : (@available[name] || [])
+    available = []
+    unavailable = []
+
+    pool.each do |candidate|
+      spec = candidate[:spec]
+
+      unless requests.all? { |request| request[:dependency].requirement.satisfied_by?(spec.version) }
+        if include_unavailable
+          state = candidate[:source] == :loaded ? ' is already activated and does not' : ' does not'
+          unavailable << "#{spec.full_name}#{state} satisfy all version requirements"
+        end
+        next
+      end
+
+      if (reason = runtime_incompatibility(spec))
+        unavailable << reason if include_unavailable
+        next
+      end
+
+      available << candidate
+    end
+
+    available = available.sort do |left, right|
+      source = source_priority(left[:source]) <=> source_priority(right[:source])
+      source == 0 ? (right[:spec].version <=> left[:spec].version) : source
+    end
+
+    include_unavailable ? [available, unavailable] : available
+  end
+
+  def runtime_incompatibility(spec)
+    unless spec.required_ruby_version.satisfied_by?(Gem.ruby_version)
+      return "#{spec.full_name} does not support Ruby #{Gem.ruby_version}"
+    end
+
+    unless spec.required_rubygems_version.satisfied_by?(Gem::Version.new(Gem::VERSION))
+      return "#{spec.full_name} does not support RubyGems #{Gem::VERSION}"
+    end
+
+    platform_matches = if Gem::Platform.respond_to?(:match_spec?)
+                         Gem::Platform.match_spec?(spec)
+                       elsif Gem::Platform.respond_to?(:match)
+                         Gem::Platform.match(spec.platform)
+                       else
+                         true
+                       end
+    unless platform_matches
+      return "#{spec.full_name} does not support platform #{Gem::Platform.local}"
+    end
+
+    nil
+  end
+
+  def source_priority(source)
+    case source
+    when :loaded then 0
+    when :application then 1
+    when :package_locked then 2
+    else 3
+    end
+  end
+
+  def add_requirement(requirements, dependency, parent)
+    requirements[dependency.name] ||= []
+    requirements[dependency.name] << { :dependency => dependency, :parent => parent }
+  end
+
+  def duplicate_requirements(requirements)
+    copy = {}
+    requirements.each { |name, requests| copy[name] = requests.dup }
+    copy
+  end
+
+  def requirements_text(name, requests)
+    details = requests.map { |request| "#{request[:parent]} requires #{request[:dependency]}" }
+    "#{name} (#{details.join(', ')})"
+  end
+
+  def unavailable_message(name, requests, unavailable)
+    message = "No candidate can satisfy #{requirements_text(name, requests)}"
+    unavailable.empty? ? "#{message}; no candidate is available" : "#{message}; #{unavailable.join(', ')}"
+  end
+
+  def state_key(selected, requirements)
+    chosen = selected.keys.sort.map do |name|
+      candidate = selected[name]
+      "#{name}=#{candidate[:spec].full_name}@#{candidate[:source]}"
+    end
+    requested = requirements.keys.sort.map do |name|
+      values = requirements[name].map do |request|
+        "#{request[:dependency].requirement}:#{request[:parent]}"
+      end.sort
+      "#{name}=#{values.join('&')}"
+    end
+
+    "#{chosen.join('|')}::#{requested.join('|')}"
+  end
+end

--- a/test/bin/resolver_test.rb
+++ b/test/bin/resolver_test.rb
@@ -1,0 +1,89 @@
+resolver_path = File.expand_path('../../src/mod/resolver.rb', __dir__)
+resolver_module = Module.new
+resolver_module.module_eval(File.read(resolver_path), resolver_path)
+resolver_class = resolver_module.const_get(:Resolver)
+conflict_class = resolver_module.const_get(:Conflict)
+
+def resolver_spec(name, version, dependencies = [])
+  Gem::Specification.new do |spec|
+    spec.name = name
+    spec.version = version
+    spec.summary = name
+    spec.authors = ['test']
+    spec.files = []
+    dependencies.each { |dependency| spec.add_runtime_dependency(*dependency) }
+  end
+end
+
+def resolver_candidate(spec, source = :package)
+  { :spec => spec, :source => source }
+end
+
+root = resolver_spec('root', '1.0', [['adapter', '>= 1']])
+adapter_2 = resolver_spec('adapter', '2.0', [['core', '>= 2']])
+adapter_1 = resolver_spec('adapter', '1.0', [['core', '< 2']])
+core_1 = resolver_spec('core', '1.0')
+available = {
+  'root' => [resolver_candidate(root)],
+  'adapter' => [resolver_candidate(adapter_1), resolver_candidate(adapter_2)],
+  'core' => [resolver_candidate(core_1)],
+}
+
+selected = resolver_class.new(available, {}).resolve(Gem::Dependency.new('root'))
+raise 'resolver did not backtrack to adapter 1.0' unless selected['adapter'][:spec].version == Gem::Version.new('1.0')
+
+locked_adapter = resolver_spec('adapter', '1.25', [['core', '< 2']])
+available['adapter'] << resolver_candidate(locked_adapter, :package_locked)
+selected = resolver_class.new(available, {}).resolve(Gem::Dependency.new('root'))
+raise 'resolver did not prefer the package lockfile candidate' unless selected['adapter'][:spec] == locked_adapter
+
+application_adapter = resolver_spec('adapter', '1.5', [['core', '< 2']])
+available['adapter'] << resolver_candidate(application_adapter, :application)
+selected = resolver_class.new(available, {}).resolve(Gem::Dependency.new('root'))
+raise 'resolver did not prefer the application candidate' unless selected['adapter'][:spec] == application_adapter
+
+fallback_root = resolver_spec('fallback-root', '1.0', [['choice', '>= 1']])
+application_choice = resolver_spec('choice', '1.0', [['missing', '>= 1']])
+package_choice = resolver_spec('choice', '2.0')
+fallback_available = {
+  'fallback-root' => [resolver_candidate(fallback_root)],
+  'choice' => [resolver_candidate(application_choice, :application), resolver_candidate(package_choice)],
+}
+selected = resolver_class.new(fallback_available, {}).resolve(Gem::Dependency.new('fallback-root'))
+raise 'resolver did not backtrack from an unsatisfiable application candidate' unless selected['choice'][:spec] == package_choice
+
+runtime_root = resolver_spec('runtime-root', '1.0', [['runtime-choice', '>= 1']])
+runtime_bad = resolver_spec('runtime-choice', '2.0')
+runtime_bad.required_ruby_version = Gem::Requirement.new('> 999')
+runtime_good = resolver_spec('runtime-choice', '1.0')
+runtime_available = {
+  'runtime-root' => [resolver_candidate(runtime_root)],
+  'runtime-choice' => [resolver_candidate(runtime_bad), resolver_candidate(runtime_good)],
+}
+selected = resolver_class.new(runtime_available, {}).resolve(Gem::Dependency.new('runtime-root'))
+raise 'resolver did not skip a runtime-incompatible candidate' unless selected['runtime-choice'][:spec] == runtime_good
+
+platform_root = resolver_spec('platform-root', '1.0', [['platform-choice', '>= 1']])
+platform_bad = resolver_spec('platform-choice', '2.0')
+platform_bad.platform = Gem::Platform.new('definitely-not-local-platform')
+platform_good = resolver_spec('platform-choice', '1.0')
+platform_available = {
+  'platform-root' => [resolver_candidate(platform_root)],
+  'platform-choice' => [resolver_candidate(platform_bad), resolver_candidate(platform_good)],
+}
+selected = resolver_class.new(platform_available, {}).resolve(Gem::Dependency.new('platform-root'))
+raise 'resolver did not skip a platform-incompatible candidate' unless selected['platform-choice'][:spec] == platform_good
+
+loaded_core = resolver_spec('core', '1.5')
+loaded_available = available.merge('core' => [resolver_candidate(resolver_spec('core', '1.8'))])
+selected = resolver_class.new(loaded_available, { 'core' => loaded_core }).resolve(Gem::Dependency.new('root'))
+raise 'resolver did not preserve a compatible activated gem' unless selected['core'][:source] == :loaded
+
+begin
+  conflict_root = resolver_spec('conflict-root', '1.0', [['core', '< 2']])
+  conflict_available = available.merge('conflict-root' => [resolver_candidate(conflict_root)])
+  resolver_class.new(conflict_available, { 'core' => resolver_spec('core', '2.0') }).resolve(Gem::Dependency.new('conflict-root'))
+  raise 'resolver accepted an incompatible activated gem'
+rescue conflict_class => e
+  raise 'resolver conflict did not identify activated gem' unless e.message.include?('already activated')
+end

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -1,5 +1,7 @@
 INJECTION_DIR = File.expand_path(File.join(__dir__, '..', '..'))
 
+require_relative 'resolver_test'
+
 # Idealised syntax
 #
 # fixture:unbundled

--- a/test/bin/test.rb
+++ b/test/bin/test.rb
@@ -342,6 +342,104 @@ SUITE = [
 
     [{ resolution: :local }] => [
 
+    [
+      { fixture: 'direct', inject: true, injector: 'datadog', packaged: true, direct: true, read_only: true },
+      { fixture: 'direct', inject: true, injector: 'datadog', packaged: true, direct: true, read_only: true, entrypoint: 'ruby' },
+    ] => {
+      [
+        { engine: 'ruby', version: '2.6' },
+        { engine: 'ruby', version: '2.7' },
+        { engine: 'ruby', version: '3.0' },
+        { engine: 'ruby', version: '3.1' },
+        { engine: 'ruby', version: '3.2' },
+        { engine: 'ruby', version: '3.3' },
+        { engine: 'ruby', version: '3.4' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
+      ] => [
+        'telemetry should include metadata.tracer_version',
+        'telemetry should include complete',
+        'app gemfile should not include datadog',
+        'app lockfile should not include datadog',
+        'new gemfile should not exist',
+        'new lockfile should not exist',
+        'telemetry start should not include result report',
+        'telemetry conclusion should include result report',
+        'reported result type should be success',
+      ],
+    },
+    { fixture: 'common', inject: true, injector: 'datadog', packaged: true, direct: true } => {
+      [
+        { engine: 'ruby', version: '2.6' },
+        { engine: 'ruby', version: '2.7' },
+        { engine: 'ruby', version: '3.0' },
+        { engine: 'ruby', version: '3.1' },
+        { engine: 'ruby', version: '3.2' },
+        { engine: 'ruby', version: '3.3' },
+        { engine: 'ruby', version: '3.4' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
+      ] => [
+        'telemetry should include metadata.tracer_version',
+        'telemetry should include complete',
+        'app gemfile should not include datadog',
+        'app lockfile should not include datadog',
+        'new gemfile should not exist',
+        'new lockfile should not exist',
+        'telemetry start should not include result report',
+        'telemetry conclusion should include result report',
+        'reported result type should be success',
+      ],
+    },
+    { fixture: 'vendored', inject: true, injector: 'datadog', packaged: true, direct: true } => {
+      [
+        { engine: 'ruby', version: '2.6' },
+        { engine: 'ruby', version: '2.7' },
+        { engine: 'ruby', version: '3.0' },
+        { engine: 'ruby', version: '3.1' },
+        { engine: 'ruby', version: '3.2' },
+        { engine: 'ruby', version: '3.3' },
+        { engine: 'ruby', version: '3.4' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
+      ] => [
+        'telemetry should include metadata.tracer_version',
+        'telemetry should include complete',
+        'app gemfile should not include datadog',
+        'app lockfile should not include datadog',
+        'new gemfile should not exist',
+        'new lockfile should not exist',
+        'telemetry start should not include result report',
+        'telemetry conclusion should include result report',
+        'reported result type should be success',
+      ],
+    },
+    { fixture: 'conflict', inject: true, injector: 'datadog', packaged: true, direct: true } => {
+      [
+        { engine: 'ruby', version: '2.6' },
+        { engine: 'ruby', version: '2.7' },
+        { engine: 'ruby', version: '3.0' },
+        { engine: 'ruby', version: '3.1' },
+        { engine: 'ruby', version: '3.2' },
+        { engine: 'ruby', version: '3.3' },
+        { engine: 'ruby', version: '3.4' },
+        { engine: 'ruby', version: '3.5', env: 'DD_INTERNAL_RUBY_INJECTOR_FORCE=ruby.version' },
+        { engine: 'ruby', version: '4.0' },
+      ] => [
+        'telemetry should include metadata.tracer_version',
+        'telemetry should include error',
+        'error reason should include bundler.direct.resolve',
+        'app gemfile should not include datadog',
+        'app lockfile should not include datadog',
+        'new gemfile should not exist',
+        'new lockfile should not exist',
+        'telemetry start should not include result report',
+        'telemetry conclusion should include result report',
+        'reported result type should be error',
+        'reported result class should be incompatible_dependency',
+      ],
+    },
+
     { fixture: 'frozen', inject: true, injector: 'datadog', packaged: true } => {
       [
         { engine: 'ruby', version: '2.6' },
@@ -724,6 +822,10 @@ example 'error reason should include bundler.inject.resolve' do |context|
   context.telemetry.any? { |e| e['points'].any? { |p| p['name'] == 'library_entrypoint.error' && p['tags'].include?('reason:bundler.inject.resolve') } }
 end
 
+example 'error reason should include bundler.direct.resolve' do |context|
+  context.telemetry.any? { |e| e['points'].any? { |p| p['name'] == 'library_entrypoint.error' && p['tags'].include?('reason:bundler.direct.resolve') } }
+end
+
 example 'app gemfile should not include datadog' do |context|
   gemfile = File.join(context.path, 'Gemfile')
   !File.read(gemfile).include?('gem "datadog"') rescue nil
@@ -835,7 +937,7 @@ def with_toolchain(*args)
   ['sh', '-c', 'if [ -f /opt/rh/devtoolset-10/enable ]; then . /opt/rh/devtoolset-10/enable; fi; exec "$@"', 'sh', *args]
 end
 
-def run(*args, engine: nil, version: nil, arch: nil, title: nil, network: true)
+def run(*args, engine: nil, version: nil, arch: nil, title: nil, network: true, read_only: false)
   env = args.first.is_a?(Hash) ? args.shift : {}
 
   runtime = RUNTIMES[engine][version] if engine && version
@@ -870,7 +972,7 @@ def run(*args, engine: nil, version: nil, arch: nil, title: nil, network: true)
       --volume datadog-injector-rb-bundle-shared-#{engine}-#{tag}-#{arch}:/usr/local/bundle:rw
       --volume datadog-injector-rb-bundle-deployment-#{engine}-#{tag}-#{arch}:#{Dir.pwd}/vendor/bundle:rw
       --volume datadog-injector-rb-bundle-path-#{engine}-#{tag}-#{arch}:/bundle:rw
-      --volume #{Dir.pwd}:#{Dir.pwd}:rw
+      --volume #{Dir.pwd}:#{Dir.pwd}:#{read_only ? 'ro' : 'rw'}
       --workdir #{Dir.pwd}
       --platform linux/#{arch}
     ]
@@ -1093,20 +1195,23 @@ def main(argv)
 
           # test with local resolution by default
           env['DD_INTERNAL_RUBY_INJECTOR_RESOLUTION'] = 'remote' if group[:resolution] == :remote
+          env['DD_INTERNAL_RUBY_INJECTOR_DIRECT'] = 'true' if group[:direct]
 
           env['RUBYOPT'] = "-r#{INJECTION_DIR}/src/injector.rb"
 
           network = group[:resolution] == :remote
 
-          pid, status = if lock
+          pid, status = if lock && group[:entrypoint] != 'ruby'
                           run env, *%W[ bundle exec ruby stub.rb ],
                               engine: group[:engine], version: group[:version],
                               network: network,
+                              read_only: group[:read_only],
                               title: 'run fixture stub'
                         else
                           run env, *%W[ ruby stub.rb ],
                               engine: group[:engine], version: group[:version],
                               network: network,
+                              read_only: group[:read_only],
                               title: 'run fixture stub'
                         end
 

--- a/test/fixtures/common/stub.rb
+++ b/test/fixtures/common/stub.rb
@@ -10,6 +10,10 @@ puts "stub:#{stub} GEM_PATH:#{ENV['GEM_PATH'].inspect}"
 puts "stub:#{stub} Gem.path:#{Gem.path.inspect}"
 puts "stub:#{stub} deps:#{Gem.loaded_specs.map { |name, spec| [name, spec.version.to_s] }.inspect}"
 
+if ENV['DD_INTERNAL_RUBY_INJECTOR_DIRECT'] == 'true' && Gem.loaded_specs['ffi'].version.to_s != '1.17.0'
+  raise 'Direct injection did not preserve the application ffi version'
+end
+
 if Gem.loaded_specs['datadog']
   require 'datadog'
   puts "stub:#{stub} datadog:#{!!defined?(Datadog)}"

--- a/test/fixtures/direct/Gemfile
+++ b/test/fixtures/direct/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rack'

--- a/test/fixtures/direct/stub.rb
+++ b/test/fixtures/direct/stub.rb
@@ -1,0 +1,23 @@
+stub = File.basename(File.dirname(File.expand_path(__FILE__)))
+
+puts "stub:#{stub} start"
+
+at_exit { puts "stub:#{stub} exit" }
+
+if File.writable?(Dir.pwd)
+  raise 'Direct injection fixture unexpectedly has a writable application directory'
+end
+
+unless defined?(Datadog::SingleStepInstrument::LOADED)
+  raise 'Datadog was not loaded by direct injection'
+end
+
+if ENV['DD_INTERNAL_RUBY_INJECTOR_PATCH']
+  raise 'Direct injection unexpectedly enabled the Bundler patch'
+end
+
+if ENV['BUNDLE_GEMFILE'] && File.basename(ENV['BUNDLE_GEMFILE']) == 'datadog.gemfile'
+  raise 'Direct injection unexpectedly replaced the application Gemfile'
+end
+
+puts "stub:#{stub} datadog:true"


### PR DESCRIPTION
### Why?

The current injector creates an augmented Gemfile and lockfile beside the application's Gemfile, then patches Bundler for deployment and vendored configurations. That requires the application directory to be writable and prevents SSI from loading in read-only containers.

This draft explores an opt-in path that activates the application bundle normally and loads the packaged Datadog SDK without modifying Bundler's definition or writing application files.

### What does this PR do?

- Adds experimental `DD_INTERNAL_RUBY_INJECTOR_DIRECT=true` mode.
- Skips the writable-filesystem guard only in direct mode.
- Activates the original application bundle through `bundler/setup` without patching Bundler.
- Resolves the packaged `datadog` gem's complete runtime dependency graph with a deterministic, memoized backtracking solver:
  - already activated gems are immutable constraints;
  - unactivated application-bundle gems are preferred;
  - package-lockfile versions are preferred next;
  - additional dependency versions installed in the package are fallback candidates;
  - Ruby, RubyGems, platform, version, and all transitive requirements are validated before activation;
  - the Datadog SDK itself remains limited to the package lockfile.
- Adds only selected package require paths and specs to RubyGems, then loads `datadog/single_step_instrument` by absolute path.
- Defers loading from a `bundle`/`bundler` CLI process so `bundle exec` loads Datadog only in the application child.
- Reports setup, resolution, and load failures separately; dependency conflicts are classified as `incompatible_dependency`.
- Leaves the existing injection path unchanged when the flag is absent.

### How to test the change?

Focused component coverage passed for:

```console
# Real read-only bind mount, bundle exec and plain Ruby entrypoints
ruby test/bin/test.rb --filter fixture:direct,entrypoint:nil,engine:ruby,version:4.0
ruby test/bin/test.rb --filter fixture:direct,entrypoint:ruby,engine:ruby,version:4.0
ruby test/bin/test.rb --filter fixture:direct,entrypoint:nil,engine:ruby,version:2.6

# Compatible app-owned dependency, vendored bundle, and genuine conflict
ruby test/bin/test.rb --filter fixture:common,direct:true,engine:ruby,version:4.0
ruby test/bin/test.rb --filter fixture:vendored,direct:true,engine:ruby,version:4.0
ruby test/bin/test.rb --filter fixture:conflict,direct:true,engine:ruby,version:4.0

# Synthetic dependency graphs: backtracking, source preference, runtime/platform
# constraints, compatible activated gems, and irreconcilable activated conflicts
ruby test/bin/resolver_test.rb
```

The full direct slice passed on Ruby 2.6 and 4.0: 47 assertions each, no failures or errors. A Ruby 1.8 default-mode startup case also passed, verifying that the always-imported resolver remains compatible with the injector's parser baseline.

### Additional Notes:

This is intentionally a separate draft from #66 and does not depend on it.

Direct mode resolves only from local application and injection-package specs and never accesses the network. It mutates `$LOAD_PATH` and `Gem.loaded_specs` only after the complete dependency graph validates. No resolver can safely replace an incompatible gem that Ruby has already activated or supply a dependency/platform build absent from both local candidate sets; those cases fail with `bundler.direct.resolve`.

Known limitations for review:

- A load failure can leave Ruby constants or loaded features created before `datadog/single_step_instrument` reports failure, even though injected paths/spec registrations are rolled back.
- Ruby 4 currently emits a promoted-stdlib warning for package-provided `logger`; loading still succeeds.

Current Ruby 3.2–4.0 matrix failures are an unrelated Bundler 4.0.16 frozen-lockfile checksum regression. The same case reproduces on untouched `main`, with direct mode unavailable/disabled.
